### PR TITLE
Adding binding parameter to host call binding.  Also `cargo fmt`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wapc-guest"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["waPC team <alothien@gmail.com>"]
 edition = "2018"
 description = "Guest SDK for building waPC-compliant WebAssembly Modules"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pub fn handle_wapc(operation: &str, msg: &[u8]) -> CallResult {
 
 fn hello_world(
    _msg: &[u8]) -> CallResult {
-   let _res = host_call("sample:Host", "Call", b"hello")?;
+   let _res = host_call("myBinding", "sample:Host", "Call", b"hello")?;
     Ok(vec![])
 }
 ```

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,9 +14,8 @@
 
 //! Glob imports for common guest module development
 
-
-pub use crate::Result;
 pub use crate::host_call;
 pub use crate::wapc_handler;
+pub use crate::Result;
 
 pub type CallResult = ::std::result::Result<Vec<u8>, Box<dyn std::error::Error>>;


### PR DESCRIPTION
Adding a `binding` argument to `__host_call` to allow the Host to route the call between potentially multiple components that serve the same `namespace`.

Fixes #5 